### PR TITLE
Flex Channel Created treatment

### DIFF
--- a/middleware/flex-custom-webchat.js
+++ b/middleware/flex-custom-webchat.js
@@ -8,7 +8,7 @@ const client = require('twilio')(
   process.env.TWILIO_AUTH_TOKEN
 );
 
-var flexChannel = false;
+var flexChannelCreated;
 
 function sendChatMessage(serviceSid, channelSid, chatUserName, body) {
   console.log('Sending new chat message');
@@ -67,13 +67,15 @@ function createNewChannel(flexFlowSid, flexChatService, chatUserName) {
     });
 }
 
-async function resetChannel() {
-  flexChannel = false;
+async function resetChannel(status) {
+  if (status == 'INACTIVE') {
+    flexChannelCreated = false;
+  }
 }
 
 async function sendMessageToFlex(msg) {
-  if (!flexChannel) {
-    flexChannel = await createNewChannel(
+  if (!flexChannelCreated) {
+    flexChannelCreated = await createNewChannel(
       process.env.FLEX_FLOW_SID,
       process.env.FLEX_CHAT_SERVICE,
       'custom-chat-user'
@@ -81,7 +83,7 @@ async function sendMessageToFlex(msg) {
   }
   sendChatMessage(
     process.env.FLEX_CHAT_SERVICE,
-    flexChannel,
+    flexChannelCreated,
     'socketio-chat-user',
     msg
   );

--- a/middleware/flex-custom-webchat.js
+++ b/middleware/flex-custom-webchat.js
@@ -8,7 +8,7 @@ const client = require('twilio')(
   process.env.TWILIO_AUTH_TOKEN
 );
 
-var flexChannel;
+var flexChannel = false;
 
 function sendChatMessage(serviceSid, channelSid, chatUserName, body) {
   console.log('Sending new chat message');
@@ -67,6 +67,10 @@ function createNewChannel(flexFlowSid, flexChatService, chatUserName) {
     });
 }
 
+async function resetChannel() {
+  flexChannel = false;
+}
+
 async function sendMessageToFlex(msg) {
   if (!flexChannel) {
     flexChannel = await createNewChannel(
@@ -83,4 +87,5 @@ async function sendMessageToFlex(msg) {
   );
 }
 
-module.exports = sendMessageToFlex;
+exports.sendMessageToFlex = sendMessageToFlex;
+exports.resetChannel = resetChannel;

--- a/middleware/server.js
+++ b/middleware/server.js
@@ -8,7 +8,7 @@ require('dotenv').load();
 const http = require('http');
 const express = require('express');
 const ngrok = require('ngrok');
-const sendMessageToFlex = require('./flex-custom-webchat');
+const flex = require('./flex-custom-webchat');
 
 // Create Express webapp and connect socket.io
 var app = express();
@@ -33,13 +33,14 @@ app.post('/new-message', function(request, response) {
 app.post('/channel-update', function(request, response) {
   console.log('Twilio channel update webhook fired');
   console.log('Channel Status: ' + JSON.parse(request.body.Attributes).status)
+  flex.resetChannel();
   response.sendStatus(200);
 });
 
 io.on('connection', function(socket) {
   console.log('User connected');
   socket.on('chat message', function(msg) {
-    sendMessageToFlex(msg);
+    flex.sendMessageToFlex(msg);
     io.emit('chat message', msg);
   });
 });

--- a/middleware/server.js
+++ b/middleware/server.js
@@ -32,8 +32,9 @@ app.post('/new-message', function(request, response) {
 
 app.post('/channel-update', function(request, response) {
   console.log('Twilio channel update webhook fired');
-  console.log('Channel Status: ' + JSON.parse(request.body.Attributes).status)
-  flex.resetChannel();
+  let status = JSON.parse(request.body.Attributes).status;
+  console.log('Channel Status: ' + status);
+  flex.resetChannel(status);
   response.sendStatus(200);
 });
 


### PR DESCRIPTION
Resets the channel when the chat is ended on the Flex side. 
The webhook is captured when the chat is ended from Flex side and set the flexChannel back to false. This starts a new chat the next time a user sends some message